### PR TITLE
Fix autoMap for single read filenames not matching `$rawFileSrchStr1`

### DIFF
--- a/autoInstall.pl
+++ b/autoInstall.pl
@@ -199,7 +199,6 @@ get_DBs();
 
 if ($condaDBinstall){
 	print "Finished LotuS2 DB install (Conda autointall)\nEnjoy LotuS2!\n";
-	@txt = addInfoLtS("RDPjar","rdp_classifier",\@txt,1);
 	exit(0)
 }
 
@@ -1239,12 +1238,7 @@ sub get_programs{
 	system("unzip -o -q $exe -d $bdir");
 	unlink($exe);
 	$exe = $bdir."rdp_classifier_2.12/dist/classifier.jar";
-	if ($condaDBinstall){
-		@txt = addInfoLtS("RDPjar","rdp_classifier",\@txt,1);
-	} else {
-		@txt = addInfoLtS("RDPjar",$exe,\@txt,1);
-	}
-	
+	@txt = addInfoLtS("RDPjar",$exe,\@txt,1);
 
 
 

--- a/lotus2.pl
+++ b/lotus2.pl
@@ -5493,7 +5493,7 @@ sub autoMap{
 				@h{(@pa2)} = undef;
 				@pa1 = grep {not exists $h{$_}} @pa1;
 			}
-			if (@pa1 != @pa2){
+			if (not @pa1 or @pa1 != @pa2){
 				$paired=1;
 			}
 		}


### PR DESCRIPTION
but matching `$rawSingSrchStr` (e.g. input1.fastq.gz, input2.fastq.gz, ...).